### PR TITLE
Better detection of C++ files

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -82,7 +82,7 @@ case `$ASTYLE --version 2> /dev/null` in
 esac
 
 mkdir -p ${BACKUPDIR}
-files=$(git-diff-index --diff-filter=ACMR --name-only -r --cached $against -- | grep '.c\|.cpp\|.hpp\|.h')
+files=$(git-diff-index --diff-filter=ACMR --name-only -r --cached $against -- | grep -i '\.c$\|\.cpp$\|\.hpp$\|\.h$')
 for file in $files; do
     x=`echo $file`
     if test "x$x" != "x"; then


### PR DESCRIPTION
Ignore case, check extension at the end of the file name.